### PR TITLE
Remove spaces from generated model names

### DIFF
--- a/lib/definitions.js
+++ b/lib/definitions.js
@@ -74,12 +74,12 @@ internals.append = function(definitionName, definition, currentCollection, force
     // else create a new item using definitionName or next model number
     if (forceDynamicName) {
       if (settings.definitionPrefix === 'useLabel') {
-        out = internals.nextModelName(definitionName + ' ', currentCollection);
+        out = internals.nextModelName(definitionName, currentCollection);
       } else {
-        out = internals.nextModelName('Model ', currentCollection);
+        out = internals.nextModelName('Model', currentCollection);
       }
     } else {
-      out = definitionName || internals.nextModelName('Model ', currentCollection);
+      out = definitionName || internals.nextModelName('Model', currentCollection);
     }
     currentCollection[out] = definition;
   }


### PR DESCRIPTION
Spaces plus encodeUriComponent yields a %20 which is not a valid identifier

Difference:
![image](https://user-images.githubusercontent.com/969938/63520264-05b1a480-c4ba-11e9-9318-f7a184e10276.png)


#599